### PR TITLE
Allow zero values for numChans and SR in neuropixelsGLX reader

### DIFF
--- a/+ndr/+format/+neuropixelsGLX/read.m
+++ b/+ndr/+format/+neuropixelsGLX/read.m
@@ -44,8 +44,8 @@ function [data, t, t0_t1] = read(binfilename, t0, t1, options)
         binfilename (1,:) char {mustBeFile}
         t0 (1,1) double
         t1 (1,1) double
-        options.numChans (1,1) {mustBeInteger, mustBePositive} = 0
-        options.SR (1,1) {mustBeNumeric, mustBePositive} = 0
+        options.numChans (1,1) {mustBeInteger, mustBeNonnegative} = 0
+        options.SR (1,1) {mustBeNumeric, mustBeNonnegative} = 0
         options.channels (1,:) {mustBeNumeric, mustBeInteger, mustBePositive} = []
     end
 


### PR DESCRIPTION
## Summary
Updated input validation for the neuropixelsGLX reader to allow zero as a valid value for `numChans` and `SR` parameters.

## Changes
- Changed `numChans` validation from `mustBePositive` to `mustBeNonnegative`, allowing 0 as a valid input
- Changed `SR` validation from `mustBePositive` to `mustBeNonnegative`, allowing 0 as a valid input

## Details
These parameters previously required strictly positive values (> 0), but the default value of 0 suggests that zero should be a valid input state. This change aligns the validation constraints with the intended default behavior, allowing users to pass 0 to indicate that these parameters should use default or auto-detected values.

https://claude.ai/code/session_01GQqT3LvvCKZ7tm7TCphrL1