### PR TITLE
Authenticate GitHub API calls in symmetry test workflow

### DIFF
--- a/.github/workflows/test-symmetry.yml
+++ b/.github/workflows/test-symmetry.yml
@@ -15,6 +15,13 @@ jobs:
   run_tests:
     name: Run symmetry tests
     runs-on: ubuntu-latest
+    # matbox resolves and downloads its MATLAB dependencies (e.g.
+    # vhlab-toolbox-matlab) through the GitHub API. Give it the runner's built-in
+    # token (auto-provided; no secret to configure) so those calls are
+    # authenticated (5000 req/hr) instead of hitting the shared unauthenticated
+    # limit (60 req/hr), which was intermittently failing dependency install.
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Check out repo
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
Added GitHub token authentication to the symmetry test workflow to improve reliability of dependency resolution and downloads.

## Changes
- Added `GITHUB_TOKEN` environment variable to the test job, using the runner's built-in `github.token`
- This authenticates matbox's GitHub API calls when resolving MATLAB dependencies (e.g., vhlab-toolbox-matlab)

## Details
The matbox tool downloads dependencies through the GitHub API. Without authentication, these calls hit the shared unauthenticated rate limit of 60 requests/hour, which was intermittently causing dependency installation failures. By providing the runner's built-in token, authenticated API calls now benefit from the higher limit of 5000 requests/hour, improving workflow reliability.

No additional secrets need to be configured—the `github.token` is automatically provided by GitHub Actions.

https://claude.ai/code/session_01Byk4ZfPKsV5xdmZUCxKeJP