### PR TITLE
tiffstack: fix datatype() for multi-sample (C&gt;1) TIFFs

### DIFF
--- a/+ndr/+reader/tiffstack.m
+++ b/+ndr/+reader/tiffstack.m
@@ -378,6 +378,15 @@ classdef tiffstack < ndr.reader.base
 				fmt = 'Unsigned';
 				if isfield(fi,'SampleFormat') && ~isempty(fi(1).SampleFormat)
 					fmt = fi(1).SampleFormat;
+					% For a multi-sample (C>1) TIFF, imfinfo returns one
+					% SampleFormat per sample (a cell array, or a char matrix
+					% with one row per sample); use the first sample's format so
+					% the SWITCH below sees a single character vector.
+					if iscell(fmt)
+						fmt = fmt{1};
+					elseif ischar(fmt) && size(fmt,1) > 1
+						fmt = fmt(1,:);
+					end
 				end
 				switch lower(fmt)
 					case {'ieeefloat','float'}


### PR DESCRIPTION
## Summary

Follow-up to #115. Fixes a crash in `ndr.reader.tiffstack` when reading an interleaved multi-channel (C>1) TIFF.

## Problem

`ndr.reader.tiffstack.tiffclass` did `switch lower(fmt)` on `fi.SampleFormat`. For a multi-sample TIFF, `imfinfo` returns **one `SampleFormat` per sample** (a cell array, or a char matrix with one row per sample), so the `switch` threw:

```
MATLAB:badSwitchExpression — SWITCH expression must be a scalar or a character vector.
  in ndr.reader.tiffstack.tiffclass (switch lower(fmt))
  in ndr.reader.tiffstack/datatype
  in ndr.reader.tiffstack/readframes
```

`framesize` already reports `C = SamplesPerPixel` for such stacks, so `datatype()` must handle them too — the two were inconsistent.

## Fix

Take the first sample's format (handling both the cell-array and multi-row-char forms) before the `switch`, mirroring how `bits` already uses `BitsPerSample(1)`.

## Impact

Unblocks reading interleaved multi-channel TIFFs through `tiffstack` (and, via the NDI image DAQ path, `SelectC` on such stacks). Surfaced by the companion NDI-matlab `imageSelectCTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017etk6N4Q5LKb3Bki7T34a5)_